### PR TITLE
Chef 17361

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -29,8 +29,8 @@ class Chef
       class Yum < Chef::Provider::Package
         include Chef::Mixin::GetSourceFromPackage
 
-        provides :package, platform_family: %w{rhel fedora amazon aix}
-        provides :yum_package, os: %{linux aix}
+        provides :package, platform_family: %w{rhel fedora amazon}
+        provides :yum_package, os: "linux"
 
         # Multipackage API
         allow_nils

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -29,8 +29,8 @@ class Chef
       class Yum < Chef::Provider::Package
         include Chef::Mixin::GetSourceFromPackage
 
-        provides :package, platform_family: %w{rhel fedora amazon}
-        provides :yum_package, os: "linux"
+        provides :package, platform_family: %w{rhel fedora amazon aix}
+        provides :yum_package, os: %{linux aix}
 
         # Multipackage API
         allow_nils

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -29,8 +29,8 @@ class Chef
       class Yum < Chef::Provider::Package
         include Chef::Mixin::GetSourceFromPackage
 
-        provides :package, platform_family: %w{rhel fedora amazon}
-        provides :yum_package, os: "linux"
+        provides :package, platform_family: %w{rhel fedora amazon aix}
+        provides :yum_package, os: %w{linux aix}
 
         # Multipackage API
         allow_nils


### PR DESCRIPTION
### Description

This pull request solves Chef ticket nr 17361 (https://getchef.zendesk.com/hc/en-us/requests/17361) :  When using yum_package on AIX, the yum_package provider responds with the following error message 
 (even when yum is installed on AIX) : 

Error executing action `install` on resource 'yum_package[logrotate]' 
Cannot find a provider for yum_package[logrotate] on aix version 7.1

When looking at the implementation of yum_package, it seems indeed that only linux as platform is supported.  

When applying this patch, yum_package works successfully on AIX . 

### Issues Resolved

Chef ticket nr 17361 (https://getchef.zendesk.com/hc/en-us/requests/17361)

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
